### PR TITLE
Use preferred tile.openstreetmap.org URL

### DIFF
--- a/src/mixins/Layers.js
+++ b/src/mixins/Layers.js
@@ -22,7 +22,7 @@ export default {
             });
         },
         mapnikLayer: function () {
-            return L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            return L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
                 maxZoom: 21,
                 attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
             });


### PR DESCRIPTION
I would like to suggest using the now preferred https://tile.openstreetmap.org URL instead of the current one (`{s}`), see

https://github.com/openstreetmap/operations/issues/737